### PR TITLE
Fix orchestrator rules path resolution and remove acorn dependency

### DIFF
--- a/codex-orchestrator/agents/readerAgent.js
+++ b/codex-orchestrator/agents/readerAgent.js
@@ -1,23 +1,14 @@
 import fs from "fs";
-import acorn from "acorn";
 
 export function analyzeCode(filePath) {
   const code = fs.readFileSync(filePath, "utf-8");
-  const ast = acorn.parse(code, { ecmaVersion: "latest", sourceType: "module" });
 
   const functions = [];
-  walkAST(ast, node => {
-    if (node.type === "FunctionDeclaration") functions.push(node.id.name);
-  });
+  const functionPattern = /function\s+([A-Za-z0-9_]+)/g;
+  let match;
+  while ((match = functionPattern.exec(code))) {
+    functions.push(match[1]);
+  }
 
   return { functions, sideEffects: [], dataFlow: "TODO" };
-}
-
-function walkAST(node, fn) {
-  fn(node);
-  for (const key in node) {
-    const child = node[key];
-    if (Array.isArray(child)) child.forEach(n => n?.type && walkAST(n, fn));
-    else if (child?.type) walkAST(child, fn);
-  }
 }

--- a/codex-orchestrator/examples/orchestrate.js
+++ b/codex-orchestrator/examples/orchestrate.js
@@ -12,7 +12,9 @@ if (!targetFile) {
   process.exit(1);
 }
 
-const rulesPath = path.resolve("./rules/commission-rules.json");
+const rulesPath = path.resolve(
+  new URL("../rules/commission-rules.json", import.meta.url).pathname,
+);
 const code = fs.readFileSync(targetFile, "utf-8");
 
 console.log("🔍 Analyzing...");


### PR DESCRIPTION
## Summary
- derive the rules JSON path from the orchestrator script location so it no longer depends on the cwd
- simplify the reader agent's function detection to avoid relying on the missing acorn dependency

## Testing
- node codex-orchestrator/examples/orchestrate.js codex-orchestrator/agents/calculateCommission.js

------
https://chatgpt.com/codex/tasks/task_e_68ca98874428832492bb32990cc04ba0